### PR TITLE
Conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ By the end of this course, you will learn how to:
 
 ## Installation ([Video instructions](https://www.youtube.com/watch?v=6_XKD3wrJ1g&t=1885s))
  
-At this time, **anaconda environments** are not tested or supported. It is recommended to install [python3.13](https://www.python.org/downloads/release/python-3139/) or use an existing Python 3.11 or newer installation.
+* **Update (21-10-2025)**: **anaconda** has been added and tested against [miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install). Simply run `setup-conda.sh`/`setup-conda.ps1` instead of `setup.sh`/`setup.ps1` in Step 3 of the instructions.
+* **Python version**: If not using conda, it is recommended to install [python3.13](https://www.python.org/downloads/release/python-3139/) or use an existing Python 3.11 or newer installation.
 
 ### 1. Clone this Repository to your Computer
 
@@ -33,12 +34,11 @@ Alternatively, you may wish to use [GitHub Desktop](https://desktop.github.com/d
 
 ### 2. Set up your Earthdata Login
 
-1. If you do not already have an account, go to [Earthdata Login](https://urs.earthdata.nasa.gov/) and create one. Note down the username and password you used for this account.
+* If you do not already have an account, go to [Earthdata Login](https://urs.earthdata.nasa.gov/) and create one. Note down the username and password you used for this account.
 
-2. **Note for some users**: Follow the instructions on this page: [https://disc.gsfc.nasa.gov/earthdata-login](https://disc.gsfc.nasa.gov/earthdata-login). If you received an **Error 401: Unauthorized** when attempting to run the code in the notebook, it is likely due to not having added the permissions for the NASA GESDISC Data Archive.
+* **Note for some users**: Follow the instructions on this page: [https://disc.gsfc.nasa.gov/earthdata-login](https://disc.gsfc.nasa.gov/earthdata-login). If you received an **Error 401: Unauthorized** when attempting to run the code in the notebook, it is likely due to not having added the permissions for the NASA GESDISC Data Archive.
 
-3. **Create a new file called .env in the same directory as this readme (the repository root) and put your username and password into it the same way you see it in .env.example:**
-
+* **Create a new file called .env in the same directory as this readme (the repository root) and put your username and password into it the same way you see it in .env.example:**
 ```bash
 EARTHDATA_USERNAME=user
 EARTHDATA_PASSWORD=pass
@@ -52,10 +52,18 @@ The provided setup script will install the required packages **and open the note
 ```bash
 ./setup.sh
 ```
+or if using **conda**:
+```bash
+./setup-conda.sh
+```
 
 **On Windows**
 ```powershell
 .\setup.ps1
+```
+or if using **conda**:
+```powershell
+./setup-conda.ps1
 ```
 
 If you would like to just open the notebook on subsequent uses, assuming your environment is set up, simply run the following command from the `SIF-ARSET` directory:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,26 @@
+name: sif-arset
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.11
+  - beautifulsoup4
+  - cartopy
+  - contextily
+  - geopandas
+  - imageio
+  - ipykernel
+  - jupyter
+  - matplotlib
+  - netcdf4
+  - notebook
+  - numpy
+  - pandas
+  - pydap
+  - python-dotenv
+  - rasterio
+  - rasterstats
+  - requests
+  - requests-cache
+  - scikit-learn
+  - tqdm

--- a/setup-conda.ps1
+++ b/setup-conda.ps1
@@ -1,0 +1,11 @@
+# Create conda environment from environment.yml
+conda env create -f environment.yml
+
+# Activate the environment  
+conda activate sif-arset
+
+# Install the kernel for Jupyter
+python -m ipykernel install --user --name=sif-arset --display-name "Python (sif-arset)"
+
+# Launch Jupyter Lab with the first notebook
+jupyter lab notebooks\1_exploration.ipynb

--- a/setup-conda.sh
+++ b/setup-conda.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+conda env create -f environment.yml
+source activate sif-arset
+python -m ipykernel install --user --name=sif-arset --display-name "Python (sif-arset)"
+jupyter lab notebooks/1_exploration.ipynb


### PR DESCRIPTION
Added option to install via conda. This was only tested against miniconda 3.13 on my personal Mac and PC. On NASA networks, the conda-forge channel is blocked due to NASA policy, and no one was able to tell me how I am supposed to set up a conda environment on the NASA network. 

In general, since most students are outside of NASA and the conda-forge channel should work for them by default, I'm willing to push this since I think it will help unblock more people than it will create problems for.